### PR TITLE
Anonymizes IP, adds page path and title to nojs GA tracking

### DIFF
--- a/sites/all/themes/pul_base/templates/system/html.tpl.php
+++ b/sites/all/themes/pul_base/templates/system/html.tpl.php
@@ -64,7 +64,7 @@
 <body<?php print $attributes;?>>
   <!-- No JS for Analytics -->
   <noscript>
-    <img src="http://www.google-analytics.com/collect?v=1&t=pageview&tid=UA-15870237-13&cid=1234&dl=nojs&dt=No%20Javascript%20User">
+    <img src="http://www.google-analytics.com/collect?v=1&tid=UA-15870237-13&aip=1&t=pageview&cid=1234&dp=/<?php print drupal_get_path_alias(current_path()); ?>&dt=<?php print drupal_get_title(); ?> (No Javascript User)" alt="">
   </noscript>
   <?php print $page_top; ?>
   <?php print $page; ?>


### PR DESCRIPTION
@kevinreiss This produces page path and title of pageview in GA:
<img width="592" alt="Screen Shot 2019-04-10 at 8 22 08 PM" src="https://user-images.githubusercontent.com/8161144/55922266-62c55180-5bce-11e9-9829-a67b17ea28d9.png">

This is an enhancement from the current tracking:
<img width="541" alt="Screen Shot 2019-04-10 at 8 22 51 PM" src="https://user-images.githubusercontent.com/8161144/55922278-6fe24080-5bce-11e9-9f2c-7cdcbcb4b97a.png">
