### PR TITLE
adding a primary drupal machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,14 @@ $aliases['local'] = array(
 ```
 drush @librarymain.prod sql-dump --structure-tables-list='watchdog,sessions,cas_data_login,history,captcha_sessions,cache,cache_*' > dumpfile.sql
 ```
+
+## Uploading and importing a SQL dump
+capistrano can be used to import a sql dump onto one of the servers.  It will upload the dump file to the server, import the dump via drush, then clear and update the search index. You should create the sql dump and then run
+```
+SQL_DIR=<path_to_sql_dump_file> SQL_FILE=<dump_file_name> cap production drupal:database:import_dump
+```
+
+For example if my sql dump file is in `/tmp/dump.sql` I would run:
+```
+SQL_DIR=/tmp/ SQL_FILE=dump.sql cap production drupal:database:import_dump
+```

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,6 +14,8 @@ set :drupal_site, "default"
 set :drupal_file_temporary_path, "../../shared/tmp"
 set :drupal_file_public_path, "sites/default/files"
 set :drupal_file_private_path, "sites/default/files/private"
+set :cas_cert_location, "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+set :smtp_host, "lib-ponyexpr.princeton.edu"
 
 set :user, "deploy"
 
@@ -66,7 +68,7 @@ namespace :drupal do
   desc "Link shared drupal files"
   task :link_files do
     on roles(:app) do |host|
-      execute "cd #{release_path}/sites/#{fetch(:drupal_site)} && ln -sf #{fetch(:drupal_fileshare_mount)}/staging_files files"
+      execute "cd #{release_path}/sites/#{fetch(:drupal_site)} && ln -sf #{fetch(:drupal_fileshare_mount)}/#{fetch(:files_dir)} files"
       execute "cd #{release_path}/sites/all/themes/pul_base && ln -sf #{shared_path}/node_modules node_modules"
       info "linked files mount into #{fetch(:drupal_site)} site"
     end
@@ -83,8 +85,8 @@ namespace :drupal do
 
   desc "Clear the drupal cache"
   task :cache_clear do
-      on release_roles :app do
-          execute "cd #{release_path} && drush -r #{release_path} cc all"
+      on release_roles :drupal_primary do
+          execute "sudo -u www-data /usr/local/bin/drush -r #{release_path} cc all"
           info "cleared the drupal cache"
         end
   end
@@ -101,7 +103,7 @@ namespace :drupal do
   desc "Set the site offline"
   task :site_offline do
       on release_roles :app do
-          execute "cd #{release_path} && drush -r #{release_path} vset --exact maintenance_mode 1"
+          execute "drush -r #{release_path} vset --exact maintenance_mode 1"
           info "set site to offline"
       end
   end
@@ -109,7 +111,7 @@ namespace :drupal do
   desc "Set the site online"
   task :site_online do
       on release_roles :app do
-          execute "cd #{release_path} && drush -r #{release_path} vdel -y --exact maintenance_mode"
+          execute "drush -r #{release_path} vdel -y --exact maintenance_mode"
           info "set site to onffline"
       end
   end
@@ -117,15 +119,15 @@ namespace :drupal do
   desc "Set file system variables"
   task :set_file_system_variables do
       on release_roles :app do
-          execute "cd #{release_path} && drush -r #{release_path} vset --exact file_temporary_path #{fetch(:drupal_file_temporary_path)}"
-          execute "cd #{release_path} && drush -r #{release_path} vset --exact file_public_path #{fetch(:drupal_file_public_path)}"
-          execute "cd #{release_path} && drush -r #{release_path} vset --exact file_private_path #{fetch(:drupal_file_private_path)}"
+          execute "drush -r #{release_path} vset --exact file_temporary_path #{fetch(:drupal_file_temporary_path)}"
+          execute "drush -r #{release_path} vset --exact file_public_path #{fetch(:drupal_file_public_path)}"
+          execute "drush -r #{release_path} vset --exact file_private_path #{fetch(:drupal_file_private_path)}"
       end
   end
 
   desc "Enable SMTP module"
   task :enable_smtp do
-      on release_roles :app do
+      on release_roles :drupal_primary do
           execute "cd #{release_path} && drush -r #{release_path} -y en --resolve-dependencies smtp"
           info "Enabled the smtp module"
       end
@@ -134,25 +136,63 @@ namespace :drupal do
   desc "change the owner of the directory to www-data for apache"
   task :update_directory_owner do
       on release_roles :app do
-        execute :sudo, "/bin/chown -R www-data /var/www/library_cap"
+        execute :sudo, "/bin/chown -R www-data #{release_path}"
+        execute :sudo, "/bin/chown -R www-data /var/www/library_cap/current/"
       end
   end
   
+  desc "change the owner of the directory to deploy"
+  task :update_directory_owner_deploy do
+      on release_roles :app do
+        execute :sudo, "/bin/chown -R deploy /var/www/library_cap/releases/*"
+      end
+  end
+
+  desc "change the owner of the directory to www-data for apache"
+  task :restart_apache2 do
+      on release_roles :app do
+        execute :sudo, "/usr/sbin/service apache2 restart"
+      end
+  end
+
   namespace :database do
 
     desc "Run Drush SQL Client against a local sql file SQL_DIR/SQL_FILE"
     task :import_dump do
-        on roles(:all) do |host|
+      invoke "drupal:site_offline"
+      on release_roles :drupal_primary do
           upload! ENV["SQL_DIR"] + ENV["SQL_FILE"], '/tmp/'+ENV["SQL_FILE"]
-          execute "cd #{release_path} && drush sql-cli < /tmp/"+ENV["SQL_FILE"]
+          execute "drush -r #{release_path} sql-cli < /tmp/"+ENV["SQL_FILE"]
+      end
+      invoke "drupal:database:update_db_variables"
+      invoke "drupal:site_online"
+      invoke "drupal:database:clear_search_index"
+      invoke "drupal:database:update_search_index"
+    end
+
+    desc "Update variables on a dump import"
+    task :update_db_variables do
+      on release_roles :drupal_primary do
+        execute "drush -r #{release_path} vset --exact smtp_host #{fetch(:smtp_host)}"
+        execute "drush -r #{release_path} vset --exact cas_cert #{fetch(:cas_cert_location)}"
+        solr_host = fetch(:search_api_solr_host)
+        solr_path = fetch(:search_api_solr_path)
+        sql = "update search_api_server set options='a:20:{s:14:\\\"clean_ids_form\\\";a:0:{}s:9:\\\"clean_ids\\\";b:0;s:14:\\\"site_hash_form\\\";a:0:{}s:9:\\\"site_hash\\\";b:0;s:6:\\\"scheme\\\";s:4:\\\"http\\\";s:4:\\\"host\\\";s:#{ solr_host.length }:\\\"#{ solr_host }\\\";s:4:\\\"port\\\";s:4:\\\"8983\\\";s:4:\\\"path\\\";s:#{solr_path.length}:\\\"#{ solr_path }\\\";s:9:\\\"http_user\\\";s:0:\\\"\\\";s:9:\\\"http_pass\\\";s:0:\\\"\\\";s:7:\\\"excerpt\\\";i:1;s:13:\\\"retrieve_data\\\";i:1;s:14:\\\"highlight_data\\\";i:0;s:17:\\\"skip_schema_check\\\";i:0;s:12:\\\"solr_version\\\";s:0:\\\"\\\";s:11:\\\"http_method\\\";s:4:\\\"AUTO\\\";s:9:\\\"log_query\\\";i:0;s:12:\\\"log_response\\\";i:0;s:17:\\\"autocorrect_spell\\\";i:1;s:25:\\\"autocorrect_suggest_words\\\";i:1;}' where id = 1;"
+        execute "drush -r #{release_path} sql-query \"#{sql}\""
+      end
+    end
+
+    desc "Clear the solr index"
+    task :clear_search_index do
+        on release_roles :drupal_primary do
+            execute "sudo -u www-data /usr/local/bin/drush -r #{release_path} search-api-clear"
         end
     end
 
     desc "Update the solr index"
     task :update_search_index do
-        on release_roles :app do
-            execute "cd #{release_path} && drush search-api-clear"
-            execute "cd #{release_path} && drush search-api-index"
+        on release_roles :drupal_primary do
+            execute "sudo -u www-data /usr/local/bin/drush -r #{release_path} search-api-index"
         end
     end
   end
@@ -175,12 +215,19 @@ namespace :deploy do
       invoke "drupal:enable_smtp"
       invoke "drupal:cache_clear"
   end
-      
+     
+  desc "Reset directory permissions and Restart apache"
+  task :after_cleanup do
+      invoke "drupal:update_directory_owner"
+      invoke "drupal:restart_apache2"
+  end
+
   after :check, "deploy:after_deploy_check"
 
   #after :started, "drupal:site_offline"
   
   after :updated, "deploy:after_deploy_updated"
 
-  #after :finished, "drupal:site_online"
+  before :finishing, "drupal:update_directory_owner_deploy"
+  after :cleanup, "deploy:after_cleanup"
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,5 +2,9 @@ set :branch, ENV["BRANCH"] || "master"
 
 set :files_dir, "production_files"
 
-server "library-prod1", user: fetch(:user), roles: %w{app}
+server "library-prod1", user: fetch(:user), roles: %w{app drupal_primary}
 server "library-prod3", user: fetch(:user), roles: %w{app}
+
+set :search_api_solr_host, 'lib-solr.princeton.edu'
+# TODO: This should be a production location
+set :search_api_solr_path, '/solr/libwww-staging'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,3 +4,6 @@ set :files_dir, "staging_files"
 
 server "library-staging1", user: fetch(:user), roles: %w{app}
 server "library-staging2", user: fetch(:user), roles: %w{app}
+
+set :search_api_solr_host, 'lib-solr.princeton.edu'
+set :search_api_solr_path, '/solr/libwww-staging'


### PR DESCRIPTION
Primary drupal machine allows commands such as clear cache and enabling smtp to be run on a single machine
Also set permissions to allow for releases to be cleaned up
Also restart apache2 after each deploy to make sure the latest changes are picked up
Adding commands for importing a sqldump