### PR TITLE
Updating ids for Marquand calendars

### DIFF
--- a/sites/all/modules/custom/libhours/libhours.module
+++ b/sites/all/modules/custom/libhours/libhours.module
@@ -83,7 +83,7 @@ drupal_add_css(drupal_get_path('module', 'libhours') . '/libhours.css');
   $lew = "<li><a href='/lewis' class='library-hours-link' style='border-left:".$lewColor." 35px solid'>".$lewTitle.$lewHours."</a></li>";
 
   $marqRss = new DOMDocument();
-  $marqRss->load('https://libcal.princeton.edu/api_hours_today.php?iid=771&lid=12313&format=xml&systemTime=1');
+  $marqRss->load('https://libcal.princeton.edu/api_hours_today.php?iid=771&lid=18259&format=xml&systemTime=1');
   $marqHours = $marqRss->getElementsByTagName('rendered')->item(0)->nodeValue;
   $marqHours = "<div class='hours'>".$marqHours."</div>";
   $marqTitle = "<h3>Marquand Art Library</h3>";

--- a/sites/all/modules/custom/libhours_marquand/libhours_marquand.module
+++ b/sites/all/modules/custom/libhours_marquand/libhours_marquand.module
@@ -29,12 +29,12 @@ function libhours_marquand_block_view() {
   $mainEnd = "</ul>";
 
   $marqRss = new DOMDocument();
-  $marqRss->load('https://libcal.princeton.edu/api_hours_today.php?iid=771&lid=12313&format=xml&systemTime=1');
+  $marqRss->load('https://libcal.princeton.edu/api_hours_today.php?iid=771&lid=18259&format=xml&systemTime=1');
   $marqHours = $marqRss->getElementsByTagName('rendered')->item(0)->nodeValue;
   $marq = "<li class='hours'>".$marqHours."</li>";
 
   $fullSchedule = "<p>For summer, holidays or recess hours, please consult the <a href='https://libcal.princeton.edu/hours'>full schedule</a>.</p>";
-  
+
   $hoursMain = $mainStart.$marq.$mainEnd.$fullSchedule;
 
   $content = $hoursMain;


### PR DESCRIPTION
This is the new calendar under Firestone in libcal

fixes #1814