### PR TITLE
Style links

### DIFF
--- a/sites/all/modules/custom/pul_custom_page_layouts/pul_custom_page_layouts.pages_default.inc
+++ b/sites/all/modules/custom/pul_custom_page_layouts/pul_custom_page_layouts.pages_default.inc
@@ -3057,15 +3057,18 @@ function pul_custom_page_layouts_default_page_manager_pages() {
     'title' => 'Panel',
   );
   $display = new panels_display();
-  $display->layout = 'six-six';
+  $display->layout = 'pul-base-four-four-four-stacked';
   $display->layout_settings = array();
   $display->panel_settings = array(
     'style_settings' => array(
+      'bottom' => NULL,
       'default' => NULL,
       'first' => NULL,
       'left' => NULL,
       'right' => NULL,
       'second' => NULL,
+      'third' => NULL,
+      'top' => NULL,
     ),
   );
   $display->cache = array();
@@ -3080,7 +3083,7 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   $pane->panel = 'first';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
-  $pane->shown = TRUE;
+  $pane->shown = FALSE;
   $pane->access = array();
   $pane->configuration = array(
     'arguments' => array(
@@ -3102,34 +3105,8 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   $display->content['new-40401fb7-3ccb-4847-8dfe-8a5d48e00616'] = $pane;
   $display->panels['first'][0] = 'new-40401fb7-3ccb-4847-8dfe-8a5d48e00616';
   $pane = new stdClass();
-  $pane->pid = 'new-42c0b272-55b0-423e-a163-b25fcf44bb7d';
-  $pane->panel = 'first';
-  $pane->type = 'views_panes';
-  $pane->subtype = 'featured_pul_link_group-panel_pane_1';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'arguments' => array(
-      'tid' => '5008',
-    ),
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_class' => '',
-    'css_id' => 'specialized-research-resources',
-  );
-  $pane->extras = array();
-  $pane->position = 1;
-  $pane->locks = array();
-  $pane->uuid = '42c0b272-55b0-423e-a163-b25fcf44bb7d';
-  $display->content['new-42c0b272-55b0-423e-a163-b25fcf44bb7d'] = $pane;
-  $display->panels['first'][1] = 'new-42c0b272-55b0-423e-a163-b25fcf44bb7d';
-  $pane = new stdClass();
   $pane->pid = 'new-25196fdc-3ae4-4d62-8d47-953cf51b512c';
-  $pane->panel = 'second';
+  $pane->panel = 'first';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
   $pane->shown = TRUE;
@@ -3148,14 +3125,40 @@ function pul_custom_page_layouts_default_page_manager_pages() {
     'css_id' => 'pul-research-resources',
   );
   $pane->extras = array();
-  $pane->position = 0;
+  $pane->position = 1;
   $pane->locks = array();
   $pane->uuid = '25196fdc-3ae4-4d62-8d47-953cf51b512c';
   $display->content['new-25196fdc-3ae4-4d62-8d47-953cf51b512c'] = $pane;
-  $display->panels['second'][0] = 'new-25196fdc-3ae4-4d62-8d47-953cf51b512c';
+  $display->panels['first'][1] = 'new-25196fdc-3ae4-4d62-8d47-953cf51b512c';
+  $pane = new stdClass();
+  $pane->pid = 'new-42c0b272-55b0-423e-a163-b25fcf44bb7d';
+  $pane->panel = 'second';
+  $pane->type = 'views_panes';
+  $pane->subtype = 'featured_pul_link_group-panel_pane_1';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'arguments' => array(
+      'tid' => '5008',
+    ),
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_class' => '',
+    'css_id' => 'specialized-research-resources',
+  );
+  $pane->extras = array();
+  $pane->position = 0;
+  $pane->locks = array();
+  $pane->uuid = '42c0b272-55b0-423e-a163-b25fcf44bb7d';
+  $display->content['new-42c0b272-55b0-423e-a163-b25fcf44bb7d'] = $pane;
+  $display->panels['second'][0] = 'new-42c0b272-55b0-423e-a163-b25fcf44bb7d';
   $pane = new stdClass();
   $pane->pid = 'new-f59815f3-47e6-46ca-9401-17b0a38e99ac';
-  $pane->panel = 'second';
+  $pane->panel = 'third';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
   $pane->shown = TRUE;
@@ -3174,11 +3177,11 @@ function pul_custom_page_layouts_default_page_manager_pages() {
     'css_id' => 'additional-research-tools',
   );
   $pane->extras = array();
-  $pane->position = 1;
+  $pane->position = 0;
   $pane->locks = array();
   $pane->uuid = 'f59815f3-47e6-46ca-9401-17b0a38e99ac';
   $display->content['new-f59815f3-47e6-46ca-9401-17b0a38e99ac'] = $pane;
-  $display->panels['second'][1] = 'new-f59815f3-47e6-46ca-9401-17b0a38e99ac';
+  $display->panels['third'][0] = 'new-f59815f3-47e6-46ca-9401-17b0a38e99ac';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/sites/all/modules/custom/pul_custom_page_layouts/pul_custom_page_layouts.pages_default.inc
+++ b/sites/all/modules/custom/pul_custom_page_layouts/pul_custom_page_layouts.pages_default.inc
@@ -3223,15 +3223,18 @@ function pul_custom_page_layouts_default_page_manager_pages() {
     'title' => 'Panel',
   );
   $display = new panels_display();
-  $display->layout = 'six-six';
+  $display->layout = 'three-three-three-three-stacked';
   $display->layout_settings = array();
   $display->panel_settings = array(
     'style_settings' => array(
       'default' => NULL,
       'first' => NULL,
+      'fourth' => NULL,
       'left' => NULL,
       'right' => NULL,
       'second' => NULL,
+      'third' => NULL,
+      'top' => NULL,
     ),
   );
   $display->cache = array();
@@ -3242,11 +3245,37 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();
-  $pane->pid = 'new-08157df2-3e2e-40f9-a090-7fd5134cff54';
+  $pane->pid = 'new-7a37fa06-78c2-4967-9b55-c984164853e3';
   $pane->panel = 'first';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
   $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'arguments' => array(
+      'tid' => '5011',
+    ),
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_class' => '',
+    'css_id' => 'request-delivery',
+  );
+  $pane->extras = array();
+  $pane->position = 0;
+  $pane->locks = array();
+  $pane->uuid = '7a37fa06-78c2-4967-9b55-c984164853e3';
+  $display->content['new-7a37fa06-78c2-4967-9b55-c984164853e3'] = $pane;
+  $display->panels['first'][0] = 'new-7a37fa06-78c2-4967-9b55-c984164853e3';
+  $pane = new stdClass();
+  $pane->pid = 'new-08157df2-3e2e-40f9-a090-7fd5134cff54';
+  $pane->panel = 'first';
+  $pane->type = 'views_panes';
+  $pane->subtype = 'featured_pul_link_group-panel_pane_1';
+  $pane->shown = FALSE;
   $pane->access = array();
   $pane->configuration = array(
     'arguments' => array(
@@ -3262,40 +3291,14 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   );
   $pane->css = array();
   $pane->extras = array();
-  $pane->position = 0;
+  $pane->position = 1;
   $pane->locks = array();
   $pane->uuid = '08157df2-3e2e-40f9-a090-7fd5134cff54';
   $display->content['new-08157df2-3e2e-40f9-a090-7fd5134cff54'] = $pane;
-  $display->panels['first'][0] = 'new-08157df2-3e2e-40f9-a090-7fd5134cff54';
-  $pane = new stdClass();
-  $pane->pid = 'new-12d6311d-f924-4674-9140-4a9ce025c84b';
-  $pane->panel = 'first';
-  $pane->type = 'views_panes';
-  $pane->subtype = 'featured_pul_link_group-panel_pane_1';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'arguments' => array(
-      'tid' => '5012',
-    ),
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_class' => '',
-    'css_id' => 'using-collections',
-  );
-  $pane->extras = array();
-  $pane->position = 1;
-  $pane->locks = array();
-  $pane->uuid = '12d6311d-f924-4674-9140-4a9ce025c84b';
-  $display->content['new-12d6311d-f924-4674-9140-4a9ce025c84b'] = $pane;
-  $display->panels['first'][1] = 'new-12d6311d-f924-4674-9140-4a9ce025c84b';
+  $display->panels['first'][1] = 'new-08157df2-3e2e-40f9-a090-7fd5134cff54';
   $pane = new stdClass();
   $pane->pid = 'new-1990251f-5830-470d-9c11-1e220e7871ab';
-  $pane->panel = 'first';
+  $pane->panel = 'fourth';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
   $pane->shown = TRUE;
@@ -3314,11 +3317,11 @@ function pul_custom_page_layouts_default_page_manager_pages() {
     'css_id' => 'using-libraries',
   );
   $pane->extras = array();
-  $pane->position = 2;
+  $pane->position = 0;
   $pane->locks = array();
   $pane->uuid = '1990251f-5830-470d-9c11-1e220e7871ab';
   $display->content['new-1990251f-5830-470d-9c11-1e220e7871ab'] = $pane;
-  $display->panels['first'][2] = 'new-1990251f-5830-470d-9c11-1e220e7871ab';
+  $display->panels['fourth'][0] = 'new-1990251f-5830-470d-9c11-1e220e7871ab';
   $pane = new stdClass();
   $pane->pid = 'new-3064c05f-2827-4ac7-ac7e-32c9d764453d';
   $pane->panel = 'second';
@@ -3346,15 +3349,15 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   $display->content['new-3064c05f-2827-4ac7-ac7e-32c9d764453d'] = $pane;
   $display->panels['second'][0] = 'new-3064c05f-2827-4ac7-ac7e-32c9d764453d';
   $pane = new stdClass();
-  $pane->pid = 'new-7a37fa06-78c2-4967-9b55-c984164853e3';
-  $pane->panel = 'second';
+  $pane->pid = 'new-12d6311d-f924-4674-9140-4a9ce025c84b';
+  $pane->panel = 'third';
   $pane->type = 'views_panes';
   $pane->subtype = 'featured_pul_link_group-panel_pane_1';
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
     'arguments' => array(
-      'tid' => '5011',
+      'tid' => '5012',
     ),
   );
   $pane->cache = array();
@@ -3363,14 +3366,14 @@ function pul_custom_page_layouts_default_page_manager_pages() {
   );
   $pane->css = array(
     'css_class' => '',
-    'css_id' => 'request-delivery',
+    'css_id' => 'using-collections',
   );
   $pane->extras = array();
-  $pane->position = 1;
+  $pane->position = 0;
   $pane->locks = array();
-  $pane->uuid = '7a37fa06-78c2-4967-9b55-c984164853e3';
-  $display->content['new-7a37fa06-78c2-4967-9b55-c984164853e3'] = $pane;
-  $display->panels['second'][1] = 'new-7a37fa06-78c2-4967-9b55-c984164853e3';
+  $pane->uuid = '12d6311d-f924-4674-9140-4a9ce025c84b';
+  $display->content['new-12d6311d-f924-4674-9140-4a9ce025c84b'] = $pane;
+  $display->panels['third'][0] = 'new-12d6311d-f924-4674-9140-4a9ce025c84b';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/sites/all/themes/pul_base/assets/source/styles/base/_links.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/base/_links.scss
@@ -1,6 +1,5 @@
 a {
   color: $black;
-  text-decoration: none;
 
   &:hover,
   &:active,

--- a/sites/all/themes/pul_base/assets/source/styles/components/_front--resources.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/components/_front--resources.scss
@@ -51,6 +51,10 @@
     }
   }
 
+  a {
+    text-decoration: none;
+  }
+
   a::before {
     bottom: 0;
     content: "";

--- a/sites/all/themes/pul_base/assets/source/styles/components/menus/_menu--main.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/components/menus/_menu--main.scss
@@ -153,6 +153,7 @@
     a {
       color: $centered-navigation-color;
       display: inline-block;
+      text-decoration: none;
 
       @include breakpoint(max-width $desk) {
         width: 100%;

--- a/sites/all/themes/pul_base/assets/source/styles/components/news/_news--featured.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/components/news/_news--featured.scss
@@ -41,6 +41,10 @@
     flex-flow: row wrap;
   }
 
+  a {
+    text-decoration: none;
+  }
+
   // .LibrarySpotlight.news--item:nth-of-type(1) {
   //   order: 4;
   // }

--- a/sites/all/themes/pul_base/assets/source/styles/components/search/_search--results.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/components/search/_search--results.scss
@@ -36,6 +36,7 @@
     a {
       border-bottom: 1px solid $gray;
       line-height: 2rem;
+      text-decoration: none;
 
       &:hover {
         border-bottom: 1px solid $orange;


### PR DESCRIPTION
Need the updates from prod to be merged, and then this should be rebased.

Changes the layout (which is in a feature)
From:
<img width="1357" alt="Screen Shot 2021-12-21 at 2 26 12 PM" src="https://user-images.githubusercontent.com/1599081/146986872-483eea3e-4fd7-4499-877b-0ed77c176917.png">

To:
<img width="1346" alt="Screen Shot 2021-12-21 at 2 25 56 PM" src="https://user-images.githubusercontent.com/1599081/146986946-9884b786-77dd-4f8c-8729-7c05affd9581.png">

fixes #1800 

Need to go into the view and edit the style for the URL content and set it back to default
![Screen Shot 2021-12-21 at 2 27 55 PM](https://user-images.githubusercontent.com/1599081/146986799-858f798e-85d6-4f75-a4ed-adabb63b24c6.png)

