### PR TITLE
Adding focus indicator to jump menu on tab

### DIFF
--- a/sites/all/themes/pul_base/assets/source/styles/components/forms/_forms.scss
+++ b/sites/all/themes/pul_base/assets/source/styles/components/forms/_forms.scss
@@ -104,6 +104,15 @@
   margin-bottom: 1em;
 }
 
+.ctools-jump-menu-select {
+
+  &:hover,
+  &:focus {
+    background: $blue-dark;
+    color: $white;
+  }
+}
+
 .form-item.webform-component {
   margin-bottom: 1.25rem;
 


### PR DESCRIPTION
This fixes only the critical blocker issue, not the moderate issue.  refs #1821 
We may have to decide on a final approach for this component, but I believe this make enough of a difference to put it live before we have the final decision on how to rework the page.
![Screen Shot 2022-01-05 at 8 43 37 AM](https://user-images.githubusercontent.com/1599081/148227333-9163595a-7d80-43fd-a39a-438c09be73f6.png)
