### PR TITLE
Gzip the database dump for local dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ sites/*/settings*.php
 .ssh/*
 drush/librarymain.aliases.drushrc.php
 *.sql
+*.sql.gz
 
 # Ignore paths that contain user-generated content.
 sites/*/files

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ $aliases['local'] = array(
   ),
 );
 ```
-12. `lando drush @librarymain.prod sql-dump --result-file=/tmp/dump.sql; scp pulsys@{insert app-server-name}:/tmp/dump.sql .`
-13. `lando db-import dump.sql`
+12. `lando drush @librarymain.prod sql-dump --gzip --result-file=/tmp/dump.sql; scp pulsys@{insert app-server-name}:/tmp/dump.sql.gz .`
+13. `lando db-import dump.sql.gz`
 14. `lando drush rsync @librarymain.prod:%files @librarymain.local:%files`
 15. `lando drush vset --exact file_temporary_path /tmp`
 16. `lando drush uli your-username`


### PR DESCRIPTION
Saves a little bit of time downloading that big database dump during the initial setup of a dev environment