### PR TITLE
Lando should run nodejs 11.15

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -18,7 +18,7 @@ services:
     type: redis
     portforward: true
   node:
-    type: 'node:6.15'
+    type: 'node:11.15'
     globals:
       gulp-cli: latest
 tooling:


### PR DESCRIPTION
Lando is currently trying to run on node 6, which does not have async/await support (which means that I was unable to run the `lando gulp deploy` step).

Production is on nodejs 11.15, so this updates the dev environment to match.