### PR TITLE
Use amd64 emulation for lando node container

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -19,6 +19,8 @@ services:
     portforward: true
   node:
     type: 'node:11.15'
+    overrides:
+      platform: linux/amd64
     globals:
       gulp-cli: latest
 tooling:


### PR DESCRIPTION
To try this, you will have to:

- `lando destroy`
- `docker image rm node:11.15`
- `lando start`