### PR TITLE
Restore .htaccess localizations that are still current.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -57,6 +57,10 @@ DirectoryIndex index.php index.html index.htm
   </FilesMatch>
 </IfModule>
 
+# Local Redirect Rules
+Redirect /favicon.ico /sites/default/files/libicon_0.ico
+RedirectPermanent /collections/video http://libserv39.princeton.edu/departments/collectiondevelopment/forums/video/
+
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
@@ -116,6 +120,7 @@ DirectoryIndex index.php index.html index.htm
 
   # Pass all requests not referring directly to files in the filesystem to
   # index.php. Clean URLs are handled in drupal_environment_initialize().
+  RewriteCond %{REQUEST_URI} !=/server-status
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteCond %{REQUEST_URI} !=/favicon.ico


### PR DESCRIPTION
Restoring the (few) .htaccess localizations that are still relevant. Those that were not restored can be found here:

https://github.com/pulibrary/pul_library_drupal/commit/ea658298e31166203d95480680539fc93f952edc

I checked each line item in the above commit. Those not restored are either already entered into the load balancer or are no longer needed. The IP blocks if they still prove to be needed can be added to our firewall rather than be handled at this level. 