### PR TITLE
HTML-encode quotes in allsearch-api article abstracts

### DIFF
--- a/sites/all/modules/custom/summon_block/summon_search_results.js
+++ b/sites/all/modules/custom/summon_block/summon_search_results.js
@@ -64,7 +64,7 @@
                             }
                             var result_position = parseInt(index) + 1;
                             items.push('<li class="' + row_class + '"><h3><a title="' +
-                                abstract +
+                                abstract.replaceAll('"', "&quot;") +
                                 '" href="' +
                                 result['url'] +
                                 '" target="_blank">' +


### PR DESCRIPTION
If quotes are not HTML-encoded, they will close the title attribute and potentially print a lot of junk to the screen or allow an XSS vulnerability.

This was not needed for discoveryutils, since [discoveryutils used PHP's htmlspecialchars](https://github.com/pulibrary/discoveryutils/blob/9dc072aad64d54b80a5356eb492e3758fb50d7b6/classes/Summon/Response.php#L50) function to html-encode these quotes on the server side.